### PR TITLE
feat: 일기, 캐릭터, 태그 도메인 핵심 API 및 비즈니스 로직 구현

### DIFF
--- a/src/main/java/com/buddy/buddyapi/controller/CharacterController.java
+++ b/src/main/java/com/buddy/buddyapi/controller/CharacterController.java
@@ -1,0 +1,48 @@
+package com.buddy.buddyapi.controller;
+
+import com.buddy.buddyapi.dto.common.ApiResponse;
+import com.buddy.buddyapi.dto.request.CharacterNameRequest;
+import com.buddy.buddyapi.dto.response.CharacterResponse;
+import com.buddy.buddyapi.dto.response.MemberResponse;
+import com.buddy.buddyapi.entity.Member;
+import com.buddy.buddyapi.service.BuddyCharacterService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/v1")
+@RequiredArgsConstructor
+@Tag(name = "Character", description = "캐릭터 관련 API")
+public class CharacterController {
+    private final BuddyCharacterService characterService;
+
+    @Operation(summary = "캐릭터 목록 조회", description = "선택 가능한 모든 캐릭터를 조회합니다.")
+    @GetMapping("/characters")
+    public ApiResponse<List<CharacterResponse>> getCharacters() {
+        return ApiResponse.success(characterService.getAllCharacters());
+    }
+
+    @Operation(summary = "내 캐릭터 변경", description = "현재 사용자의 버디 캐릭터를 변경합니다.")
+    @PatchMapping("/users/me/character")
+    public ApiResponse<MemberResponse> changeCharacter(
+            @AuthenticationPrincipal Member member,
+            @RequestBody Map<String, Long> request) {
+        Long characterSeq = request.get("characterSeq");
+        return ApiResponse.success(characterService.changeMyCharacter(member, characterSeq));
+    }
+
+    @Operation(summary = "캐릭터 별명 변경", description = "캐릭터에게 지어준 별명을 수정합니다.")
+    @PatchMapping("/users/me/character-name")
+    public ApiResponse<String> updateCharacterName(
+            @AuthenticationPrincipal Member member,
+            @RequestBody CharacterNameRequest request) {
+        characterService.updateCharacterNickname(member, request.characterName());
+        return ApiResponse.success("캐릭터 이름이 변경되었습니다.");
+    }
+}

--- a/src/main/java/com/buddy/buddyapi/controller/DiaryController.java
+++ b/src/main/java/com/buddy/buddyapi/controller/DiaryController.java
@@ -1,0 +1,73 @@
+package com.buddy.buddyapi.controller;
+
+import com.buddy.buddyapi.dto.common.ApiResponse;
+import com.buddy.buddyapi.dto.request.DiaryCreateRequest;
+import com.buddy.buddyapi.dto.request.DiaryUpdateRequest;
+import com.buddy.buddyapi.dto.response.DiaryDetailResponse;
+import com.buddy.buddyapi.dto.response.DiaryListResponse;
+import com.buddy.buddyapi.entity.Member;
+import com.buddy.buddyapi.service.DiaryService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Tag(name="Diary", description = "일기 관련 API")
+@RestController
+@RequestMapping("/api/v1/diary")
+@RequiredArgsConstructor
+public class DiaryController {
+
+    private final DiaryService diaryService;
+
+    @Operation(summary = "일기 생성", description = "새로운 일기를 저장합니다.")
+    @PostMapping
+    public ApiResponse<Long> createDiary(
+            @AuthenticationPrincipal Member member,
+            @RequestBody DiaryCreateRequest request) {
+        return ApiResponse.success(diaryService.createDiary(member, request));
+    }
+
+    @Operation(summary = "날짜별 일기 목록 조회", description = "특정 날짜의 일기 리스트를 가져옵니다.")
+    @GetMapping
+    public ApiResponse<List<DiaryListResponse>> getDiariesByDate(
+            @AuthenticationPrincipal Member member,
+            @RequestParam @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate date) {
+        return ApiResponse.success(diaryService.getDiariesByDate(member, date));
+    }
+
+    @Operation(summary = "일기 상세 조회", description = "특정 일기의 상세 내용을 조회합니다.")
+    @GetMapping("/{diarySeq}")
+    public ApiResponse<DiaryDetailResponse> getDiaryDetail(
+            @AuthenticationPrincipal Member member,
+            @PathVariable Long diarySeq) {
+        return ApiResponse.success(diaryService.getDiaryDetail(member, diarySeq));
+    }
+
+    @Operation(summary = "일기 수정", description = "기존 일기의 내용 및 태그를 수정합니다.")
+    @PatchMapping("/{diarySeq}")
+    public ApiResponse<Long> updateDiary(
+            @AuthenticationPrincipal Member member,
+            @PathVariable Long diarySeq,
+            @RequestBody DiaryUpdateRequest request) {
+        diaryService.updateDiary(member, diarySeq, request);
+        return ApiResponse.success(diarySeq);
+    }
+
+    @Operation(summary = "일기 삭제", description = "일기를 삭제합니다.")
+    @DeleteMapping("/{diarySeq}")
+    public ApiResponse<Void> deleteDiary(
+            @AuthenticationPrincipal Member member,
+            @PathVariable Long diarySeq) {
+        diaryService.deleteDiary(member, diarySeq);
+        return ApiResponse.success(null);
+    }
+
+
+
+}

--- a/src/main/java/com/buddy/buddyapi/controller/TagController.java
+++ b/src/main/java/com/buddy/buddyapi/controller/TagController.java
@@ -1,0 +1,27 @@
+package com.buddy.buddyapi.controller;
+
+import com.buddy.buddyapi.dto.common.ApiResponse;
+import com.buddy.buddyapi.dto.response.TagResponse;
+import com.buddy.buddyapi.service.TagService;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/tags")
+@RequiredArgsConstructor
+@io.swagger.v3.oas.annotations.tags.Tag(name = "Tag", description = "태그 관련 API")
+public class TagController {
+
+    private final TagService tagService;
+
+    @Operation(summary = "태그 목록 조회", description = "서비스에서 제공하는 모든 태그 목록을 조회합니다.")
+    @GetMapping
+    public ApiResponse<List<TagResponse>> getTags() {
+        return ApiResponse.success(tagService.getAllTags());
+    }
+}

--- a/src/main/java/com/buddy/buddyapi/dto/common/ApiResponse2.java
+++ b/src/main/java/com/buddy/buddyapi/dto/common/ApiResponse2.java
@@ -1,0 +1,40 @@
+package com.buddy.buddyapi.dto.common;
+
+import com.buddy.buddyapi.global.exception.ResultCode;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+// TODO APIRESPONSE 이걸로 수정하기
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE) // 외부에서 생성자 직접 호출 방지
+public class ApiResponse2<T> {
+    private final String code;
+    private final String message;
+    private final T result;
+
+    // 1. 단순 성공 응답 (데이터 포함)
+    public static <T> ApiResponse<T> ok(T result) {
+        return new ApiResponse<>(ResultCode.SUCCESS.getCode(), ResultCode.SUCCESS.getMessage(), result);
+    }
+
+    // 2. 성공 응답 (데이터 + 커스텀 메시지)
+    public static <T> ApiResponse<T> ok(String message, T result) {
+        return new ApiResponse<>(ResultCode.SUCCESS.getCode(), message, result);
+    }
+
+    // 3. 성공 응답 (데이터 없음 - 주로 삭제나 단순 성공 알림)
+    public static <T> ApiResponse<Void> ok() {
+        return new ApiResponse<>(ResultCode.SUCCESS.getCode(), ResultCode.SUCCESS.getMessage(), null);
+    }
+
+    // 4. 에러 응답 (기본)
+    public static <T> ApiResponse<T> error(ResultCode resultCode) {
+        return new ApiResponse<>(resultCode.getCode(), resultCode.getMessage(), null);
+    }
+
+    // 5. 에러 응답 (상세 정보 포함 - Validation 에러 등 전달 시 유용)
+    public static <T> ApiResponse<T> error(ResultCode resultCode, T errorDetail) {
+        return new ApiResponse<>(resultCode.getCode(), resultCode.getMessage(), errorDetail);
+    }
+}

--- a/src/main/java/com/buddy/buddyapi/dto/request/CharacterNameRequest.java
+++ b/src/main/java/com/buddy/buddyapi/dto/request/CharacterNameRequest.java
@@ -1,0 +1,11 @@
+package com.buddy.buddyapi.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record CharacterNameRequest(
+        @NotBlank(message = "캐릭터 이름을 입력해주세요")
+        @Size(min = 1, max = 20, message = "이름은 1~20자 사이입니다.")
+        String characterName
+) {
+}

--- a/src/main/java/com/buddy/buddyapi/dto/request/DiaryCreateRequest.java
+++ b/src/main/java/com/buddy/buddyapi/dto/request/DiaryCreateRequest.java
@@ -1,0 +1,14 @@
+package com.buddy.buddyapi.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+import java.util.List;
+
+public record DiaryCreateRequest(
+        String title,
+        @NotBlank(message = "일기 내용은 필수입니다.")
+        String content,
+        String imageUrl,
+        List<Long> tagSeqs
+) {
+}

--- a/src/main/java/com/buddy/buddyapi/dto/request/DiaryGenerateRequest.java
+++ b/src/main/java/com/buddy/buddyapi/dto/request/DiaryGenerateRequest.java
@@ -1,0 +1,9 @@
+package com.buddy.buddyapi.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record DiaryGenerateRequest(
+        @NotBlank(message = "세션 ID는 필수입니다.")
+        String sessionId
+) {
+}

--- a/src/main/java/com/buddy/buddyapi/dto/request/DiaryUpdateRequest.java
+++ b/src/main/java/com/buddy/buddyapi/dto/request/DiaryUpdateRequest.java
@@ -1,0 +1,14 @@
+package com.buddy.buddyapi.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+import java.util.List;
+
+public record DiaryUpdateRequest(
+        String title,
+        @NotBlank(message = "일기 내용은 필수입니다.")
+        String content,
+        String imageUrl,
+        List<Long> tagSeqs
+) {
+}

--- a/src/main/java/com/buddy/buddyapi/dto/request/MemberRegisterRequest.java
+++ b/src/main/java/com/buddy/buddyapi/dto/request/MemberRegisterRequest.java
@@ -26,5 +26,5 @@ public class MemberRegisterRequest {
     @Size(min = 2, max = 15, message = "닉네임은 2자에서 15자 사이여야 합니다.")
     private String nickname;
 
-    private Integer characterSeq;
+    private Long characterSeq;
 }

--- a/src/main/java/com/buddy/buddyapi/dto/request/UpdateNicknameRequest.java
+++ b/src/main/java/com/buddy/buddyapi/dto/request/UpdateNicknameRequest.java
@@ -1,9 +1,6 @@
 package com.buddy.buddyapi.dto.request;
 
-
-import lombok.Getter;
-
-@Getter
-public class UpdateNicknameRequest {
-    String nickname;
+public record UpdateNicknameRequest(
+        String nickname
+) {
 }

--- a/src/main/java/com/buddy/buddyapi/dto/request/UpdatePasswordRequest.java
+++ b/src/main/java/com/buddy/buddyapi/dto/request/UpdatePasswordRequest.java
@@ -1,12 +1,8 @@
 package com.buddy.buddyapi.dto.request;
 
 
-import lombok.Getter;
-
-@Getter
-public class UpdatePasswordRequest {
-
-    private String currentPassword;
-    private String newPassword;
-
+public record UpdatePasswordRequest (
+        String currentPassword,
+        String newPassword
+) {
 }

--- a/src/main/java/com/buddy/buddyapi/dto/response/CharacterResponse.java
+++ b/src/main/java/com/buddy/buddyapi/dto/response/CharacterResponse.java
@@ -1,0 +1,21 @@
+package com.buddy.buddyapi.dto.response;
+
+import com.buddy.buddyapi.entity.BuddyCharacter;
+
+public record CharacterResponse(
+        Long characterSeq,
+        String name,
+        String description,
+        String personality,
+        String avatarUrl
+) {
+    public static CharacterResponse from(BuddyCharacter character) {
+        return new CharacterResponse(
+                character.getCharacterSeq(),
+                character.getName(),
+                character.getDescription(),
+                character.getPersonality(),
+                character.getAvatarUrl()
+        );
+    }
+}

--- a/src/main/java/com/buddy/buddyapi/dto/response/DiaryDetailResponse.java
+++ b/src/main/java/com/buddy/buddyapi/dto/response/DiaryDetailResponse.java
@@ -1,0 +1,32 @@
+package com.buddy.buddyapi.dto.response;
+
+import com.buddy.buddyapi.entity.Diary;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Builder
+public record DiaryDetailResponse(
+        Long diarySeq,
+        String title,
+        String content,
+        String imageUrl,
+        LocalDateTime createdAt,
+        List<TagResponse> tags // 태그도 seq와 name을 같이 주면 프론트가 편해요
+) {
+    public static DiaryDetailResponse from(Diary diary) {
+        return DiaryDetailResponse.builder()
+                .diarySeq(diary.getDiarySeq())
+                .title(diary.getTitle())
+                .content(diary.getContent())
+                .imageUrl(diary.getImageUrl())
+                .createdAt(diary.getCreatedAt())
+                .tags(diary.getDiaryTags().stream()
+                        .map(dt -> new TagResponse(dt.getTag().getTagSeq(), dt.getTag().getName()))
+                        .toList())
+                .build();
+    }
+
+
+}

--- a/src/main/java/com/buddy/buddyapi/dto/response/DiaryListResponse.java
+++ b/src/main/java/com/buddy/buddyapi/dto/response/DiaryListResponse.java
@@ -1,0 +1,32 @@
+package com.buddy.buddyapi.dto.response;
+
+import com.buddy.buddyapi.entity.Diary;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record DiaryListResponse(
+        Long diarySeq,
+        String title,
+        String summary,
+        LocalDateTime createAt,
+        List<String> tags
+
+) {
+    public static DiaryListResponse from(Diary diary) {
+        // TODO 본문을 60자 정도로 요약하는 로직....필요한지...생각좀...
+        String content = diary.getContent();
+        String summary = (content != null && content.length() > 60)
+                ? content.substring(0,60) + "..." : content;
+
+        return new DiaryListResponse(
+                diary.getDiarySeq(),
+                diary.getTitle(),
+                summary,
+                diary.getCreatedAt(),
+                diary.getDiaryTags().stream()
+                        .map(diaryTag -> diaryTag.getTag().getName())
+                        .toList()
+        );
+    }
+}

--- a/src/main/java/com/buddy/buddyapi/dto/response/DiaryPreviewResponse.java
+++ b/src/main/java/com/buddy/buddyapi/dto/response/DiaryPreviewResponse.java
@@ -1,0 +1,12 @@
+package com.buddy.buddyapi.dto.response;
+
+import java.util.List;
+
+public record DiaryPreviewResponse(
+        // TODO AI로 일기 생성 시 초안, 실제 채팅 연동 후 변경 예정
+        String title,
+        String content,
+        List<Long> tags
+) {
+
+}

--- a/src/main/java/com/buddy/buddyapi/dto/response/LoginResponse.java
+++ b/src/main/java/com/buddy/buddyapi/dto/response/LoginResponse.java
@@ -1,12 +1,11 @@
 package com.buddy.buddyapi.dto.response;
 
 import lombok.Builder;
-import lombok.Getter;
 
-@Getter
 @Builder
-public class LoginResponse {
-    private String accessToken;
-    private String refreshToken;
-    private MemberResponse member;
+public record LoginResponse(
+        String accessToken,
+        String refreshToken,
+        MemberResponse member
+) {
 }

--- a/src/main/java/com/buddy/buddyapi/dto/response/MemberResponse.java
+++ b/src/main/java/com/buddy/buddyapi/dto/response/MemberResponse.java
@@ -1,24 +1,30 @@
 package com.buddy.buddyapi.dto.response;
 
+import com.buddy.buddyapi.entity.BuddyCharacter;
 import com.buddy.buddyapi.entity.Member;
 import lombok.Builder;
 import lombok.Getter;
 
-@Getter
 @Builder
-public class MemberResponse {
+public record MemberResponse(
+        Long memberSeq,
+        String email,
+        String nickname,
 
-    private Long memberSeq;
-    private String email;
-    private String nickname;
-
-    // TODO 캐릭터에 관한거는
-    private Integer characterSeq;
-    private String characterName;
-    private String avatarUrl;
+        // TODO 캐릭터에 관한거는 수정
+        Long characterSeq,
+        String characterName,
+        String avatarUrl
+) {
 
     public static MemberResponse from(Member member) {
+        // 변수명을 character라고 지었으니 누가 봐도 BuddyCharacter 타입
+        // var는 java10에서 도입되어 컴파일러가 오른쪽의 대입되는 값을 보고 타입을 자동으로 알아냄(지역변수타입추론 local variable type inference)
+//        var character = member.getBuddyCharacter();
+
+        BuddyCharacter character = member.getBuddyCharacter();
         // Entity에서 비밀번호 등 민감한 필드는 제외하고, 필요한 정보만 추출
+        // TODO character관련 null 설정 맞는지 확인 해봐야할듯
         return MemberResponse.builder()
                 .memberSeq(member.getMemberSeq())
                 .email(member.getEmail())

--- a/src/main/java/com/buddy/buddyapi/dto/response/TagResponse.java
+++ b/src/main/java/com/buddy/buddyapi/dto/response/TagResponse.java
@@ -1,0 +1,12 @@
+package com.buddy.buddyapi.dto.response;
+
+import com.buddy.buddyapi.entity.Tag;
+
+public record TagResponse(
+        Long tagSeq,
+        String name
+) {
+    public static TagResponse from(Tag tag) {
+        return new TagResponse(tag.getTagSeq(), tag.getName());
+    }
+}

--- a/src/main/java/com/buddy/buddyapi/entity/BuddyCharacter.java
+++ b/src/main/java/com/buddy/buddyapi/entity/BuddyCharacter.java
@@ -15,7 +15,7 @@ public class BuddyCharacter {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "character_seq")
-    private Integer characterSeq;
+    private Long characterSeq;
 
     @Column(unique = true, nullable = false, length = 100)
     private String name;

--- a/src/main/java/com/buddy/buddyapi/entity/Diary.java
+++ b/src/main/java/com/buddy/buddyapi/entity/Diary.java
@@ -54,8 +54,20 @@ public class Diary {
     }
 
     // addTag, removeTag 추가 생각중
+    public void addTags(List<Tag> tags) {
+        tags.forEach(tag -> {
+            DiaryTag diaryTag = new DiaryTag(this, tag);
+            this.diaryTags.add(diaryTag);
+        });
+    }
 
+    public void updateTags(List<Tag> newTags) {
+        // 1. 기존 태그 리스트를 비움(orphanRemoval = true 설정 덕분에 DB에서도 삭제됨)
+        this.diaryTags.clear();
 
+        // 2. 새로운 태그들 추가
+        addTags(newTags);
+    }
 
 
 }

--- a/src/main/java/com/buddy/buddyapi/entity/DiaryTag.java
+++ b/src/main/java/com/buddy/buddyapi/entity/DiaryTag.java
@@ -5,10 +5,10 @@ import lombok.*;
 
 import java.io.Serializable;
 
+@Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "diary_tag")
-@Entity
 public class DiaryTag {
 
     @EmbeddedId

--- a/src/main/java/com/buddy/buddyapi/entity/Member.java
+++ b/src/main/java/com/buddy/buddyapi/entity/Member.java
@@ -34,6 +34,10 @@ public class Member implements UserDetails {
     @Column(name = "joined_at", nullable = false, updatable = false)
     private LocalDateTime joinedAt;
 
+    // 사용자는 직접 캐릭터의 별명을 지어줄 수 있음
+    @Column(name = "character_nickname", length = 20)
+    private String characterNickname;
+
     // -------- relation --------
 
     @ManyToOne(fetch = FetchType.LAZY)
@@ -64,6 +68,14 @@ public class Member implements UserDetails {
     }
     public void updateNickname(String nickname) {
         this.nickname = nickname;
+    }
+    public void changeCharacter(BuddyCharacter character) {
+        this.buddyCharacter = character;
+    }
+
+    // 캐릭터 별명 변경 메서드
+    public void updateCharacterNickname(String newNickname) {
+        this.characterNickname = newNickname;
     }
 
 

--- a/src/main/java/com/buddy/buddyapi/entity/Tag.java
+++ b/src/main/java/com/buddy/buddyapi/entity/Tag.java
@@ -6,21 +6,19 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+@Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "tag")
-@Entity
 public class Tag {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long tagSeq;
 
-    @Column(unique = true, nullable = false, length = 30)
+    @Column(unique = true, nullable = false, length = 20)
     private String name;
 
-
-    @Builder
     public Tag(String name) {
         this.name = name;
     }

--- a/src/main/java/com/buddy/buddyapi/global/exception/ResultCode.java
+++ b/src/main/java/com/buddy/buddyapi/global/exception/ResultCode.java
@@ -21,8 +21,9 @@ public enum ResultCode {
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER_NOT_FOUND", "존재하지 않는 사용자입니다."),
     INVALID_CREDENTIALS(HttpStatus.UNAUTHORIZED, "INVALID_CREDENTIALS", "이메일 또는 비밀번호가 불일치합니다."),
     CURRENT_PASSWORD_MISMATCH(HttpStatus.BAD_REQUEST,"CURRENT_PASSWORD_MISMATCH", "현재 비밀번호가 일치하지 않습니다."),
-    INVALID_PASSWORD_FORMAT(HttpStatus.BAD_REQUEST, "INVALID_PASSWORD_FORMAT", "비밀번호 형식이 올바르지 않습니다.");
-
+    INVALID_PASSWORD_FORMAT(HttpStatus.BAD_REQUEST, "INVALID_PASSWORD_FORMAT", "비밀번호 형식이 올바르지 않습니다."),
+    TAG_NOT_FOUND(HttpStatus.NOT_FOUND, "TAG_NOT_FOUND","태그를 찾을 수 없습니다."),
+    DIARY_NOT_FOUND(HttpStatus.NOT_FOUND, "DIARY_NOT_FOUND", "존재하지 않는 일기입니다.");
     private final HttpStatus httpStatus;
     private final String code;
     private final String message;

--- a/src/main/java/com/buddy/buddyapi/repository/BuddyCharacterRepository.java
+++ b/src/main/java/com/buddy/buddyapi/repository/BuddyCharacterRepository.java
@@ -3,5 +3,5 @@ package com.buddy.buddyapi.repository;
 import com.buddy.buddyapi.entity.BuddyCharacter;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface BuddyCharacterRepository extends JpaRepository<BuddyCharacter, Integer> {
+public interface BuddyCharacterRepository extends JpaRepository<BuddyCharacter, Long> {
 }

--- a/src/main/java/com/buddy/buddyapi/repository/DiaryRepository.java
+++ b/src/main/java/com/buddy/buddyapi/repository/DiaryRepository.java
@@ -4,13 +4,26 @@ import com.buddy.buddyapi.entity.Diary;
 import com.buddy.buddyapi.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 public interface DiaryRepository extends JpaRepository<Diary, Long> {
 
+    // 특정 맴버의 전체 일기
     List<Diary> findByMember(Member member);
     
-    //TODO 특정유저의 특정일 기록들
+    //TODO 특정 회원의 특정 기간 사이 일기 목록 조회(날짜 필터링용)
+    // 왜 맴버를 통으로 하지?
+    List<Diary> findAllByMemberAndCreatedAtBetweenOrderByCreatedAtDesc(
+            Member member,
+            LocalDateTime start,
+            LocalDateTime end
+    );
 
-    // TODO 특정일 기록중 하나
+    // TODO 일기 상세 조회 시 작성자 확인용(보안)
+    // findById로 가능 아예 Member와 함께 조회하면 권한 체크로 더 낫나??
+    Optional<Diary> findByDiarySeqAndMember(Long diarySeq, Member member);
+
+
 }

--- a/src/main/java/com/buddy/buddyapi/repository/TagRepository.java
+++ b/src/main/java/com/buddy/buddyapi/repository/TagRepository.java
@@ -3,7 +3,10 @@ package com.buddy.buddyapi.repository;
 import com.buddy.buddyapi.entity.Tag;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface TagRepository extends JpaRepository<Tag, Long> {
     boolean existsByName(String name);
-
+    // tagSeq 리스트로 한꺼번에 태그들을 찾아올 때 사용
+    List<Tag> findAllByTagSeqIn(List<Long> tagSeqs);
 }

--- a/src/main/java/com/buddy/buddyapi/service/BuddyCharacterService.java
+++ b/src/main/java/com/buddy/buddyapi/service/BuddyCharacterService.java
@@ -1,0 +1,49 @@
+package com.buddy.buddyapi.service;
+
+import com.buddy.buddyapi.dto.response.CharacterResponse;
+import com.buddy.buddyapi.dto.response.MemberResponse;
+import com.buddy.buddyapi.entity.BuddyCharacter;
+import com.buddy.buddyapi.entity.Member;
+import com.buddy.buddyapi.global.exception.BaseException;
+import com.buddy.buddyapi.global.exception.ResultCode;
+import com.buddy.buddyapi.repository.BuddyCharacterRepository;
+import com.buddy.buddyapi.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class BuddyCharacterService {
+
+    private final BuddyCharacterRepository characterRepository;
+    private final MemberRepository memberRepository;
+
+    // 1. 캐릭터 목록 전체 조회
+    public List<CharacterResponse> getAllCharacters() {
+        return characterRepository.findAll().stream()
+                .map(CharacterResponse::from)
+                .toList();
+    }
+
+    // 2. 내 캐릭터 변경
+    @Transactional
+    public MemberResponse changeMyCharacter(Member member, Long characterSeq) {
+        BuddyCharacter newCharacter = characterRepository.findById(characterSeq)
+                .orElseThrow(() -> new BaseException(ResultCode.CHARACTER_NOT_FOUND));
+
+        member.changeCharacter(newCharacter);
+        memberRepository.save(member);
+
+        return MemberResponse.from(member);
+    }
+
+    // 3. 캐릭터 별명 변경
+    @Transactional
+    public void updateCharacterNickname(Member member, String newName) {
+        member.updateCharacterNickname(newName);
+        memberRepository.save(member);
+    }
+}

--- a/src/main/java/com/buddy/buddyapi/service/DiaryService.java
+++ b/src/main/java/com/buddy/buddyapi/service/DiaryService.java
@@ -1,0 +1,102 @@
+package com.buddy.buddyapi.service;
+
+import com.buddy.buddyapi.dto.request.DiaryCreateRequest;
+import com.buddy.buddyapi.dto.request.DiaryUpdateRequest;
+import com.buddy.buddyapi.dto.response.DiaryDetailResponse;
+import com.buddy.buddyapi.dto.response.DiaryListResponse;
+import com.buddy.buddyapi.entity.Diary;
+import com.buddy.buddyapi.entity.Member;
+import com.buddy.buddyapi.entity.Tag;
+import com.buddy.buddyapi.global.exception.BaseException;
+import com.buddy.buddyapi.global.exception.ResultCode;
+import com.buddy.buddyapi.repository.DiaryRepository;
+import com.buddy.buddyapi.repository.TagRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class DiaryService {
+
+    private final DiaryRepository diaryRepository;
+    private final TagRepository tagRepository;
+
+    // 특정 날짜의 일기 목록 조회
+    public List<DiaryListResponse> getDiariesByDate(Member member, LocalDate date) {
+        // 해당 날짜의 00:00:00
+        LocalDateTime start = date.atStartOfDay();
+        // 해당 날짜의 23:59:59.999999
+        LocalDateTime end = date.atTime(LocalTime.MAX);
+
+        return diaryRepository.findAllByMemberAndCreatedAtBetweenOrderByCreatedAtDesc(member, start, end)
+                .stream()
+                .map(DiaryListResponse::from) // DTO에 만든 from 메서드 활용
+                .toList();
+    }
+
+    // 일기 저장 (Create)
+    @Transactional
+    public Long createDiary(Member member, DiaryCreateRequest request) {
+        // 1. 일기 엔티티 생성
+        Diary diary = Diary.builder()
+                .title(request.title())
+                .content(request.content())
+                .imageUrl(request.imageUrl())
+                .member(member)
+                .build();
+
+        // 2. 태그 리스트가 있다면 조회 후 연결
+        if (request.tagSeqs() != null && !request.tagSeqs().isEmpty()) {
+            List<Tag> tags = tagRepository.findAllByTagSeqIn(request.tagSeqs());
+
+            // 요청한 개수와 DB에서 찾은 개수가 다르면 예외 처리 (선택사항)
+            if (tags.size() != request.tagSeqs().size()) {
+                throw new BaseException(ResultCode.TAG_NOT_FOUND);
+            }
+
+            diary.addTags(tags);
+        }
+
+        return diaryRepository.save(diary).getDiarySeq();
+    }
+
+    @Transactional
+    public void updateDiary(Member member, Long diarySeq, DiaryUpdateRequest request) {
+        // 1. 본인의 일기인지 확인하며 조회
+        Diary diary = diaryRepository.findByDiarySeqAndMember(diarySeq, member)
+                .orElseThrow(() -> new BaseException(ResultCode.DIARY_NOT_FOUND));
+
+        // 2. 기본 정보 수정
+        diary.updateDiary(request.title(), request.content(), request.imageUrl());
+
+        // 3. 태그 교체
+        if (request.tagSeqs() != null) {
+            List<Tag> tags = tagRepository.findAllById(request.tagSeqs());
+            diary.updateTags(tags);
+        }
+    }
+
+    @Transactional
+    public void deleteDiary(Member member, Long diarySeq) {
+        Diary diary = diaryRepository.findByDiarySeqAndMember(diarySeq, member)
+                .orElseThrow(() -> new BaseException(ResultCode.DIARY_NOT_FOUND));
+
+        diaryRepository.delete(diary);
+        // diary_tag 테이블의 데이터도 알아서 같이 지워집니다!
+    }
+
+    @Transactional(readOnly = true)
+    public DiaryDetailResponse getDiaryDetail(Member member, Long diarySeq) {
+        Diary diary = diaryRepository.findByDiarySeqAndMember(diarySeq, member)
+                .orElseThrow(() -> new BaseException(ResultCode.DIARY_NOT_FOUND));
+
+        return DiaryDetailResponse.from(diary);
+    }
+
+}

--- a/src/main/java/com/buddy/buddyapi/service/MemberServiceImpl.java
+++ b/src/main/java/com/buddy/buddyapi/service/MemberServiceImpl.java
@@ -49,7 +49,7 @@ public class MemberServiceImpl implements MemberService {
         String encodedPassword = passwordEncoder.encode(request.getPassword());
 
         // 3. 초기 캐릭터 조회 및 유효성 검사
-        Integer charSeq = request.getCharacterSeq() != null ? request.getCharacterSeq() : 1;
+        Long charSeq = request.getCharacterSeq() != null ? request.getCharacterSeq() : 1;
 
         BuddyCharacter selectedCharacter = characterRepository.findById(charSeq)
                 .orElseThrow(()-> new BaseException(ResultCode.CHARACTER_NOT_FOUND));
@@ -115,7 +115,7 @@ public class MemberServiceImpl implements MemberService {
 //        }
 
         // 3. 변경 (Dirty Checking에 의해 자동 반영)
-        member.updateNickname(request.getNickname());
+        member.updateNickname(request.nickname());
 
         return new UpdateNicknameResponse(member.getNickname());
     }
@@ -128,12 +128,12 @@ public class MemberServiceImpl implements MemberService {
                 .orElseThrow(() ->  new BaseException(ResultCode.USER_NOT_FOUND));
 
         // 2. 기존 비밀번호 확인 (Spring Security의 matches 사용)
-        if (!passwordEncoder.matches(request.getCurrentPassword(), member.getPassword())) {
+        if (!passwordEncoder.matches(request.currentPassword(), member.getPassword())) {
             throw new BaseException(ResultCode.CURRENT_PASSWORD_MISMATCH);
         }
 
         // 3. 새 비밀번호 암호화 및 저장
-        String encodedNewPassword = passwordEncoder.encode(request.getNewPassword());
+        String encodedNewPassword = passwordEncoder.encode(request.newPassword());
         member.updatePassword(encodedNewPassword);
     }
 

--- a/src/main/java/com/buddy/buddyapi/service/TagService.java
+++ b/src/main/java/com/buddy/buddyapi/service/TagService.java
@@ -1,0 +1,20 @@
+package com.buddy.buddyapi.service;
+
+import com.buddy.buddyapi.dto.response.TagResponse;
+import com.buddy.buddyapi.repository.TagRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class TagService {
+    private final TagRepository tagRepository;
+
+    public List<TagResponse> getAllTags() {
+        return tagRepository.findAll().stream()
+                .map(TagResponse::from)
+                .toList();
+    }
+}

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -7,3 +7,10 @@ VALUES ('buddy1', '친절하고 따뜻한 성격으로 당신의 이야기를 �
 -- 2번 공부 캐릭터
 INSERT INTO buddy_character (name, personality, description, avatar_url)
 VALUES ('buddy2', '엄격하고 성격으로 당신의 목표 달성을 돕습니다.', '현실적으로 도움을 주는 친구입니다.', 'https://buddy-api.com/static/avatars/cool_buddy.png');
+
+
+-- 기본 태그
+INSERT INTO tag (name) VALUES ('기쁨');
+INSERT INTO tag (name) VALUES ('슬픔');
+INSERT INTO tag (name) VALUES ('회사');
+INSERT INTO tag (name) VALUES ('위로');


### PR DESCRIPTION
- Diary: 일기 생성(태그 연동), 목록 조회(날짜별), 상세 조회, 수정, 삭제 API 구현
- Character: 캐릭터 전체 목록 조회 및 사용자 캐릭터/별명 변경 기능 추가
- Tag: 서비스 공통 태그 목록 조회 API 추가
- Infrastructure: Record 기반 DTO 도입 및 ApiResponse 규격 적용
- Database: 다이어리-태그 N:M 매핑 엔티티 설계 및 JPA 연동

[Next Step]
- AI 기반 일기 초안 생성(from-chat) 로직 설계 및 Mock 데이터 구현
- SecurityConfig 내 캐릭터/태그 조회 API 권한 설정(permitAll) 반영