### PR TITLE
feat: 채팅 시스템 및 AI 연동 전 기본 로직 구현

### DIFF
--- a/src/main/java/com/buddy/buddyapi/controller/AuthController.java
+++ b/src/main/java/com/buddy/buddyapi/controller/AuthController.java
@@ -6,6 +6,7 @@ import com.buddy.buddyapi.dto.request.MemberRegisterRequest;
 import com.buddy.buddyapi.dto.response.MemberResponse;
 import com.buddy.buddyapi.dto.common.ApiResponse;
 import com.buddy.buddyapi.service.MemberService;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -14,6 +15,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "Auth", description = "Auth 관련 API")
 @RestController
 @RequestMapping("/api/v1/auth")
 @RequiredArgsConstructor

--- a/src/main/java/com/buddy/buddyapi/controller/ChatController.java
+++ b/src/main/java/com/buddy/buddyapi/controller/ChatController.java
@@ -1,0 +1,48 @@
+package com.buddy.buddyapi.controller;
+
+import com.buddy.buddyapi.dto.common.ApiResponse;
+import com.buddy.buddyapi.dto.request.ChatRequest;
+import com.buddy.buddyapi.dto.response.ChatResponse;
+import com.buddy.buddyapi.entity.Member;
+import com.buddy.buddyapi.service.ChatService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Tag(name = "Chat", description = "채팅 API")
+@RestController
+@RequestMapping("/api/v1/chats")
+@RequiredArgsConstructor
+public class ChatController {
+    private final ChatService chatService;
+
+    @Operation(summary = "메시지 전송", description = "사용자가 메시지를 보내고 AI의 답변을 받습니다.")
+    @PostMapping
+    public ApiResponse<ChatResponse> sendMessage(
+            @AuthenticationPrincipal Member member,
+            @RequestBody ChatRequest request) {
+        return ApiResponse.success(chatService.sendMessage(member, request));
+    }
+
+    @Operation(summary = "대화 내역 조회", description = "특정 세션의 모든 대화 내역을 조회합니다.")
+    @GetMapping("/{sessionId}")
+    public ApiResponse<List<ChatResponse>> getChatHistory(
+            @AuthenticationPrincipal Member member,
+            @PathVariable Long sessionId
+    ) {
+        return ApiResponse.success(chatService.getChatHistory(member,sessionId));
+    }
+
+    @Operation(summary = "대화 세션 종료", description = "대화를 종료하고 해당 세션을 일기 생성 가능 상태로 변경합니다.")
+    @PatchMapping("/{sessionId}/end")
+    public ApiResponse<String> endSession(
+            @AuthenticationPrincipal Member member,
+            @PathVariable Long sessionId) {
+        chatService.endChatSession(member, sessionId);
+        return ApiResponse.success("대화가 성공적으로 종료되었습니다. 일기를 확인해보세요!");
+    }
+}

--- a/src/main/java/com/buddy/buddyapi/controller/DiaryController.java
+++ b/src/main/java/com/buddy/buddyapi/controller/DiaryController.java
@@ -2,9 +2,11 @@ package com.buddy.buddyapi.controller;
 
 import com.buddy.buddyapi.dto.common.ApiResponse;
 import com.buddy.buddyapi.dto.request.DiaryCreateRequest;
+import com.buddy.buddyapi.dto.request.DiaryGenerateRequest;
 import com.buddy.buddyapi.dto.request.DiaryUpdateRequest;
 import com.buddy.buddyapi.dto.response.DiaryDetailResponse;
 import com.buddy.buddyapi.dto.response.DiaryListResponse;
+import com.buddy.buddyapi.dto.response.DiaryPreviewResponse;
 import com.buddy.buddyapi.entity.Member;
 import com.buddy.buddyapi.service.DiaryService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -24,6 +26,15 @@ import java.util.List;
 public class DiaryController {
 
     private final DiaryService diaryService;
+
+    // TODO AI 관련 바탕임 전체 수정 해야함
+    @Operation(summary = "대화 기반 AI 일기 생성", description = "대화 세션을 기반으로 AI가 일기 초안과 태그를 생성합니다.")
+    @PostMapping("/from-chat")
+    public ApiResponse<DiaryPreviewResponse> generateDiaryFromChat(
+            @AuthenticationPrincipal Member member,
+            @RequestBody DiaryGenerateRequest request) {
+        return ApiResponse.success(diaryService.generateDiaryFromChat(member, request));
+    }
 
     @Operation(summary = "일기 생성", description = "새로운 일기를 저장합니다.")
     @PostMapping

--- a/src/main/java/com/buddy/buddyapi/controller/MemberController.java
+++ b/src/main/java/com/buddy/buddyapi/controller/MemberController.java
@@ -7,10 +7,12 @@ import com.buddy.buddyapi.dto.response.MemberResponse;
 import com.buddy.buddyapi.dto.response.UpdateNicknameResponse;
 import com.buddy.buddyapi.entity.Member;
 import com.buddy.buddyapi.service.MemberService;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
+@Tag(name = "Member", description = "맴버 API")
 @RestController
 @RequestMapping("/api/v1/members")
 @RequiredArgsConstructor

--- a/src/main/java/com/buddy/buddyapi/domain/SenderRole.java
+++ b/src/main/java/com/buddy/buddyapi/domain/SenderRole.java
@@ -1,0 +1,6 @@
+package com.buddy.buddyapi.domain;
+
+public enum SenderRole {
+    USER,
+    ASSISTANT
+}

--- a/src/main/java/com/buddy/buddyapi/dto/request/ChatRequest.java
+++ b/src/main/java/com/buddy/buddyapi/dto/request/ChatRequest.java
@@ -1,0 +1,7 @@
+package com.buddy.buddyapi.dto.request;
+
+public record ChatRequest(
+        Long sessionId, // 처음 보낼 때는 null 가능
+        String content
+) {
+}

--- a/src/main/java/com/buddy/buddyapi/dto/response/ChatResponse.java
+++ b/src/main/java/com/buddy/buddyapi/dto/response/ChatResponse.java
@@ -1,0 +1,23 @@
+package com.buddy.buddyapi.dto.response;
+
+import com.buddy.buddyapi.entity.ChatMessage;
+
+import java.time.LocalDateTime;
+
+public record ChatResponse(
+        Long sessionId,
+        Long messageSeq,
+        String role,
+        String content,
+        LocalDateTime createdAt
+) {
+    public static ChatResponse from(ChatMessage message, Long sessionId) {
+        return new ChatResponse(
+                sessionId,
+                message.getMessageSeq(),
+                message.getRole().name(),
+                message.getContent(),
+                message.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/com/buddy/buddyapi/dto/response/DiaryPreviewResponse.java
+++ b/src/main/java/com/buddy/buddyapi/dto/response/DiaryPreviewResponse.java
@@ -6,7 +6,7 @@ public record DiaryPreviewResponse(
         // TODO AI로 일기 생성 시 초안, 실제 채팅 연동 후 변경 예정
         String title,
         String content,
-        List<Long> tags
+        List<TagResponse> tags
 ) {
 
 }

--- a/src/main/java/com/buddy/buddyapi/entity/ChatMessage.java
+++ b/src/main/java/com/buddy/buddyapi/entity/ChatMessage.java
@@ -1,0 +1,45 @@
+package com.buddy.buddyapi.entity;
+
+import com.buddy.buddyapi.domain.SenderRole;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "chat_message")
+public class ChatMessage {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "message_seq")
+    private Long messageSeq;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "session_seq", nullable = false)
+    private ChatSession chatSession;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private SenderRole role; // USER 또는 ASSISTANT(AI)
+
+    @Column(columnDefinition = "TEXT", nullable = false)
+    private String content;
+
+    @CreationTimestamp
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
+
+    @Builder
+    public ChatMessage(ChatSession chatSession, SenderRole role, String content) {
+        this.chatSession = chatSession;
+        this.role = role;
+        this.content = content;
+    }
+}

--- a/src/main/java/com/buddy/buddyapi/entity/ChatSession.java
+++ b/src/main/java/com/buddy/buddyapi/entity/ChatSession.java
@@ -1,0 +1,51 @@
+package com.buddy.buddyapi.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "chat_session")
+public class ChatSession {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long sessionSeq;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_seq", nullable = false)
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "character_seq", nullable = false)
+    private BuddyCharacter buddyCharacter;
+
+    @Column(name = "is_ended", nullable = false)
+    private boolean isEnded = false;
+
+    @CreationTimestamp
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
+
+
+    @Builder
+    public ChatSession(Member member, BuddyCharacter buddyCharacter) {
+        this.member = member;
+        this.buddyCharacter = buddyCharacter;
+    }
+
+    public void endSession() {
+        if(this.isEnded) {
+            return;
+        }
+        this.isEnded = true;
+    }
+
+}

--- a/src/main/java/com/buddy/buddyapi/global/exception/ResultCode.java
+++ b/src/main/java/com/buddy/buddyapi/global/exception/ResultCode.java
@@ -23,7 +23,9 @@ public enum ResultCode {
     CURRENT_PASSWORD_MISMATCH(HttpStatus.BAD_REQUEST,"CURRENT_PASSWORD_MISMATCH", "현재 비밀번호가 일치하지 않습니다."),
     INVALID_PASSWORD_FORMAT(HttpStatus.BAD_REQUEST, "INVALID_PASSWORD_FORMAT", "비밀번호 형식이 올바르지 않습니다."),
     TAG_NOT_FOUND(HttpStatus.NOT_FOUND, "TAG_NOT_FOUND","태그를 찾을 수 없습니다."),
-    DIARY_NOT_FOUND(HttpStatus.NOT_FOUND, "DIARY_NOT_FOUND", "존재하지 않는 일기입니다.");
+    DIARY_NOT_FOUND(HttpStatus.NOT_FOUND, "DIARY_NOT_FOUND", "존재하지 않는 일기입니다."),
+    SESSION_NOT_FOUND(HttpStatus.NOT_FOUND, "SESSION_NOT_FOUND", "특정 세션을 찾을 수 없습니다.");
+
     private final HttpStatus httpStatus;
     private final String code;
     private final String message;

--- a/src/main/java/com/buddy/buddyapi/repository/ChatMessageRepository.java
+++ b/src/main/java/com/buddy/buddyapi/repository/ChatMessageRepository.java
@@ -1,0 +1,21 @@
+package com.buddy.buddyapi.repository;
+
+import com.buddy.buddyapi.entity.ChatMessage;
+import com.buddy.buddyapi.entity.ChatSession;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> {
+    // 특정 세션의 모든 메시지를 과거 -> 최신순으로 정렬하여 조회
+    // (AI에게 문맥을 전달하거나 채팅방에 진입할 때 사용)
+    List<ChatMessage> findAllByChatSessionOrderByCreatedAtDesc(ChatSession chatSession);
+
+    // 2. 특정 세션의 메시지 개수 확인 (세션의 활성화 정도 파악용)
+//    long countByChatSession(ChatSession chatSession);
+
+    // 3. (옵션) 특정 세션의 가장 마지막 메시지 하나만 조회
+//    Optional<ChatMessage> findFirstByChatSessionOrderByCreatedAtDesc(ChatSession chatSession);
+
+    List<ChatMessage>  findAllByChatSessionOrderByCreatedAtAsc(ChatSession chatSession);
+}

--- a/src/main/java/com/buddy/buddyapi/repository/ChatSessionRepository.java
+++ b/src/main/java/com/buddy/buddyapi/repository/ChatSessionRepository.java
@@ -1,0 +1,24 @@
+package com.buddy.buddyapi.repository;
+
+import com.buddy.buddyapi.entity.ChatSession;
+import com.buddy.buddyapi.entity.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface ChatSessionRepository extends JpaRepository<ChatSession, Long> {
+    // 1. 특정 회원의 모든 대화 세션을 최신순으로 조회
+    List<ChatSession> findAllByMemberOrderByCreatedAtDesc(Member member);
+
+    // 2. 특정 회원의 세션 중 아직 종료되지 않은 (isEnded = false)
+    // 사용자가 채팅창에 들어왔을 때 기존 대화를 이어붙여줄지 결정할 때 유용함
+    Optional<ChatSession> findFirstByMemberAndIsEndedFalseOrderByCreatedAtDesc(Member member);
+
+    // 3. 특정 회원의 특정 세션 조회 (내 세션이 맞는지 검증 포함)
+    @Query( "SELECT s FROM ChatSession s " +
+            "JOIN FETCH s.buddyCharacter " +
+            "WHERE s.sessionSeq = :sessionSeq AND s.member = :member")
+    Optional<ChatSession> findBySessionSeqAndMember(Long sessionSeq, Member member);
+}

--- a/src/main/java/com/buddy/buddyapi/service/ChatService.java
+++ b/src/main/java/com/buddy/buddyapi/service/ChatService.java
@@ -1,0 +1,141 @@
+package com.buddy.buddyapi.service;
+
+import com.buddy.buddyapi.domain.SenderRole;
+import com.buddy.buddyapi.dto.request.ChatRequest;
+import com.buddy.buddyapi.dto.response.ChatResponse;
+import com.buddy.buddyapi.dto.response.DiaryPreviewResponse;
+import com.buddy.buddyapi.entity.BuddyCharacter;
+import com.buddy.buddyapi.entity.ChatMessage;
+import com.buddy.buddyapi.entity.ChatSession;
+import com.buddy.buddyapi.entity.Member;
+import com.buddy.buddyapi.global.exception.BaseException;
+import com.buddy.buddyapi.global.exception.ResultCode;
+import com.buddy.buddyapi.repository.BuddyCharacterRepository;
+import com.buddy.buddyapi.repository.ChatMessageRepository;
+import com.buddy.buddyapi.repository.ChatSessionRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ChatService {
+    private final ChatSessionRepository chatSessionRepository;
+    private final ChatMessageRepository chatMessageRepository;
+    private final BuddyCharacterRepository buddyCharacterRepository;
+
+    @Transactional
+    public ChatResponse sendMessage(Member member, ChatRequest request) {
+        // 1. 세션 조회 또는 생성 (세션 ID가 없거나 종료된 세션이면 새로 생성)
+        ChatSession session = getOrCreateSession(member, request.sessionId());
+
+        // 2. 사용자 메시지 저장
+        saveMessage(session, SenderRole.USER, request.content());
+
+        // 3. AI 답변 생성 (지금은 Mock 데이터, 나중에 AI 연동)
+        String aiContent = generateAiResponse(session, request.content());
+
+        // 4. AI 메시지 저장
+        ChatMessage aiMessage = saveMessage(session, SenderRole.ASSISTANT, aiContent);
+
+        return ChatResponse.from(aiMessage, session.getSessionSeq());
+
+    }
+
+    private ChatSession getOrCreateSession(Member member, Long sessionId) {
+        if(sessionId != null) {
+            return chatSessionRepository.findBySessionSeqAndMember(sessionId, member)
+                    .filter(s -> !s.isEnded()) // 종료되지 않은 세션만 사용
+                    .orElseGet(() -> createNewSession(member));
+        }
+        return createNewSession(member);
+    }
+
+    private ChatSession createNewSession(Member member) {
+
+        Long characterSeq = member.getBuddyCharacter().getCharacterSeq();
+
+        BuddyCharacter character = buddyCharacterRepository.findById(characterSeq)
+                .orElseThrow(() -> new BaseException(ResultCode.CHARACTER_NOT_FOUND));
+
+        // 사용자가 현재 설정한 캐릭터를 가져와서 세션 생성
+        ChatSession session = ChatSession.builder()
+                .member(member)
+                .buddyCharacter(character)
+                .build();
+
+        return  chatSessionRepository.save(session);
+    }
+
+    private ChatMessage saveMessage(ChatSession session, SenderRole role, String content) {
+        ChatMessage message = ChatMessage.builder()
+                .chatSession(session)
+                .role(role)
+                .content(content)
+                .build();
+        return chatMessageRepository.save(message);
+    }
+
+    private String generateAiResponse(ChatSession session, String userContent) {
+        // TODO: OpenAI API 연동 지점
+        // 지금은 캐릭터 이르을 불러주는 가짜 답변 반환
+        String characterName = session.getBuddyCharacter().getName();
+        return String.format("안녕! 나는 '%s'야. 네가 '%s'라고 말해줘서 정말 기뻐. 임시 답변생성임",
+                characterName, userContent);
+    }
+
+    public List<ChatResponse> getChatHistory(Member member, Long sessionId) {
+        // 내 세션인지 검증
+        ChatSession session = chatSessionRepository.findBySessionSeqAndMember(sessionId, member)
+                .orElseThrow(() -> new BaseException(ResultCode.SESSION_NOT_FOUND));
+
+        // 메시지 목록을 과거순으로 조회하여 DTO로 변환
+        return chatMessageRepository.findAllByChatSessionOrderByCreatedAtDesc(session)
+                .stream()
+                .map(msg -> ChatResponse.from(msg, sessionId))
+                .toList();
+    }
+
+    @Transactional
+    public void endChatSession(Member member, Long sessionId){
+        ChatSession session = chatSessionRepository.findBySessionSeqAndMember(sessionId, member)
+                .orElseThrow(() -> new BaseException(ResultCode.SESSION_NOT_FOUND));
+
+        // 2. 이미 종료된 세션인지 체크 (선택 사항)
+//        if (session.isEnded()) {
+//            throw new BaseException(ResultCode.SESSION_ALREADY_ENDED);
+//            // ResultCode에 SESSION_ALREADY_ENDED 하나 추가해주면 좋습니다.
+//        }
+
+        session.endSession();
+
+        chatSessionRepository.save(session);
+    }
+
+    @Transactional
+    public DiaryPreviewResponse generateDiaryFromChat(Member member, Long sessionId) {
+        // 1. 세션 존재 확인
+        ChatSession session = chatSessionRepository.findBySessionSeqAndMember(sessionId, member)
+                .orElseThrow(() -> new BaseException(ResultCode.SESSION_NOT_FOUND));
+
+        // 2. 해당 세션의 모든 메시지 순서대로 가져오기
+        List<ChatMessage> messages = chatMessageRepository.findAllByChatSessionOrderByCreatedAtAsc(session);
+
+        // 3. AI에게 전달할 대화 텍스트 생성
+        String fullConversation = messages.stream()
+                .map(m -> m.getRole() + ": " + m.getContent())
+                .collect(Collectors.joining("\n"));
+
+        // 4. TODO: fullConversation을 OpenAI API에 전달하여 요약/태그 추출
+        // 지금은 텍스트가 잘 합쳐졌는지 로그로 확인해봅시다.
+        System.out.println("AI에게 보낼 텍스트:\n" + fullConversation);
+
+        return new DiaryPreviewResponse("AI가 요약한 제목", "AI가 작성한 본문", List.of());
+    }
+
+
+}

--- a/src/main/java/com/buddy/buddyapi/service/DiaryService.java
+++ b/src/main/java/com/buddy/buddyapi/service/DiaryService.java
@@ -1,9 +1,12 @@
 package com.buddy.buddyapi.service;
 
 import com.buddy.buddyapi.dto.request.DiaryCreateRequest;
+import com.buddy.buddyapi.dto.request.DiaryGenerateRequest;
 import com.buddy.buddyapi.dto.request.DiaryUpdateRequest;
 import com.buddy.buddyapi.dto.response.DiaryDetailResponse;
 import com.buddy.buddyapi.dto.response.DiaryListResponse;
+import com.buddy.buddyapi.dto.response.DiaryPreviewResponse;
+import com.buddy.buddyapi.dto.response.TagResponse;
 import com.buddy.buddyapi.entity.Diary;
 import com.buddy.buddyapi.entity.Member;
 import com.buddy.buddyapi.entity.Tag;
@@ -26,6 +29,26 @@ public class DiaryService {
 
     private final DiaryRepository diaryRepository;
     private final TagRepository tagRepository;
+
+    // TODO 다 아님 다 고쳐야함
+    @Transactional(readOnly = true)
+    public DiaryPreviewResponse generateDiaryFromChat(Member member, DiaryGenerateRequest request) {
+        // 1. 세션 ID로 채팅 내역 조회 (나중에 ChatService 연동)
+        // TODO: chatRepository.findAllBySessionId(request.sessionId())
+
+        // 2. AI에게 요약 요청 (나중에 OpenAI/LangChain 연동)
+        // 지금은 가짜(Mock) 데이터를 반환합니다.
+        String mockTitle = "오늘의 따뜻한 기록";
+        String mockContent = "오늘은 버디와 대화하며 하루를 정리했다. 마음이 한결 가벼워진 것 같다.";
+
+        // 3. AI가 추천해준 태그 후보 (임시)
+        List<TagResponse> mockTags = List.of(
+                new TagResponse(1L, "위로"),
+                new TagResponse(4L, "일상")
+        );
+
+        return new DiaryPreviewResponse(mockTitle, mockContent, mockTags);
+    }
 
     // 특정 날짜의 일기 목록 조회
     public List<DiaryListResponse> getDiariesByDate(Member member, LocalDate date) {

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -14,3 +14,5 @@ INSERT INTO tag (name) VALUES ('기쁨');
 INSERT INTO tag (name) VALUES ('슬픔');
 INSERT INTO tag (name) VALUES ('회사');
 INSERT INTO tag (name) VALUES ('위로');
+
+-- 테스트 맴버


### PR DESCRIPTION
- Chat: 세션 기반 채팅 시스템 구현 (Session & Message 엔티티/Repository)
- Chat: 메시지 전송 시 세션 자동 생성 및 캐릭터 정보 연동 로직 추가
- Chat: JPA Fetch Join을 사용하여 LazyInitializationException 성능 최적화
- Chat: 세션 종료(isEnded) 처리 및 대화 내역 시간순 조회 API 구현

[Next Step]
- OpenAI API 실제 연동 및 프롬프트 엔지니어링 적용
- AI 응답(JSON String)을 DiaryPreviewResponse로 변환하는 파싱 로직 구현