### PR TITLE
feat: 일기 날짜(diaryDate) 필드 추가 및 이미지 업로드/조회 경로 설정

### DIFF
--- a/src/main/java/com/buddy/buddyapi/controller/DiaryController.java
+++ b/src/main/java/com/buddy/buddyapi/controller/DiaryController.java
@@ -15,8 +15,10 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.MediaType;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -38,11 +40,12 @@ public class DiaryController {
     }
 
     @Operation(summary = "일기 생성", description = "새로운 일기를 저장합니다.")
-    @PostMapping
+    @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ApiResponse<Long> createDiary(
             @AuthenticationPrincipal CustomUserDetails member,
-            @Valid @RequestBody DiaryCreateRequest request) {
-        return ApiResponse.ok(diaryService.createDiary(member.memberSeq(), request));
+            @RequestPart(value = "request") @Valid DiaryCreateRequest request,
+            @RequestPart(value = "image", required = false) MultipartFile image) {
+        return ApiResponse.ok(diaryService.createDiary(member.memberSeq(), request, image));
     }
 
     @Operation(summary = "날짜별 일기 목록 조회", description = "특정 날짜의 일기 리스트를 가져옵니다.")
@@ -62,12 +65,13 @@ public class DiaryController {
     }
 
     @Operation(summary = "일기 수정", description = "기존 일기의 내용 및 태그를 수정합니다.")
-    @PatchMapping("/{diarySeq}")
+    @PatchMapping(value = "/{diarySeq}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ApiResponse<Long> updateDiary(
             @AuthenticationPrincipal CustomUserDetails member,
             @PathVariable Long diarySeq,
-            @Valid @RequestBody DiaryUpdateRequest request) {
-        diaryService.updateDiary(member.memberSeq(), diarySeq, request);
+            @RequestPart("request") @Valid DiaryUpdateRequest request,
+            @RequestPart(value = "image", required = false) MultipartFile image) {
+        diaryService.updateDiary(member.memberSeq(), diarySeq, request, image);
         return ApiResponse.ok(diarySeq);
     }
 
@@ -79,6 +83,8 @@ public class DiaryController {
         diaryService.deleteDiary(member.memberSeq(), diarySeq);
         return ApiResponse.ok();
     }
+
+
 
 
 

--- a/src/main/java/com/buddy/buddyapi/dto/request/DiaryCreateRequest.java
+++ b/src/main/java/com/buddy/buddyapi/dto/request/DiaryCreateRequest.java
@@ -1,14 +1,19 @@
 package com.buddy.buddyapi.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import org.springframework.format.annotation.DateTimeFormat;
 
+import java.time.LocalDate;
 import java.util.List;
 
 public record DiaryCreateRequest(
         String title,
         @NotBlank(message = "일기 내용은 필수입니다.")
         String content,
-        String imageUrl,
+        @NotNull(message = "일기 날짜를 입력해주세요")
+        @DateTimeFormat(pattern = "yyyy-MM-dd")
+        LocalDate diaryDate,
         List<String> tags
 ) {
 }

--- a/src/main/java/com/buddy/buddyapi/dto/request/DiaryUpdateRequest.java
+++ b/src/main/java/com/buddy/buddyapi/dto/request/DiaryUpdateRequest.java
@@ -1,14 +1,19 @@
 package com.buddy.buddyapi.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import org.springframework.format.annotation.DateTimeFormat;
 
+import java.time.LocalDate;
 import java.util.List;
 
 public record DiaryUpdateRequest(
         String title,
         @NotBlank(message = "일기 내용은 필수입니다.")
         String content,
-        String imageUrl,
+        @NotNull(message = "일기 날짜를 입력해주세요")
+        @DateTimeFormat(pattern = "yyyy-MM-dd")
+        LocalDate diaryDate,
         List<String> tags
 ) {
 }

--- a/src/main/java/com/buddy/buddyapi/dto/response/DiaryDetailResponse.java
+++ b/src/main/java/com/buddy/buddyapi/dto/response/DiaryDetailResponse.java
@@ -15,12 +15,12 @@ public record DiaryDetailResponse(
         LocalDateTime createdAt,
         List<TagResponse> tags // 태그도 seq와 name을 같이 주면 프론트가 편해요
 ) {
-    public static DiaryDetailResponse from(Diary diary) {
+    public static DiaryDetailResponse from(Diary diary, String fullImageUrl) {
         return DiaryDetailResponse.builder()
                 .diarySeq(diary.getDiarySeq())
                 .title(diary.getTitle())
                 .content(diary.getContent())
-                .imageUrl(diary.getImageUrl())
+                .imageUrl(fullImageUrl)
                 .createdAt(diary.getCreatedAt())
                 .tags(diary.getDiaryTags().stream()
                         .map(dt -> new TagResponse(dt.getTag().getTagSeq(), dt.getTag().getName()))

--- a/src/main/java/com/buddy/buddyapi/entity/Diary.java
+++ b/src/main/java/com/buddy/buddyapi/entity/Diary.java
@@ -7,6 +7,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.CreationTimestamp;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -26,6 +27,8 @@ public class Diary {
     private String title;
     @Column(columnDefinition = "TEXT")
     private String content;
+    @Column(name = "diary_date", nullable = false)
+    private LocalDate diaryDate;
     @CreationTimestamp
     @Column(name = "created_at", updatable = false)
     private LocalDateTime createdAt;
@@ -40,16 +43,18 @@ public class Diary {
     private final List<DiaryTag> diaryTags = new ArrayList<>();
 
     @Builder
-    public Diary(String title, String content, String imageUrl, Member member) {
+    public Diary(String title, String content, LocalDate diaryDate, String imageUrl, Member member) {
         this.title = title;
         this.content = content;
+        this.diaryDate = diaryDate;
         this.imageUrl = imageUrl;
         this.member = member;
     }
 
-    public void updateDiary(String title, String content, String imageUrl) {
+    public void updateDiary(String title, String content, LocalDate diaryDate, String imageUrl) {
         this.title = title;
         this.content = content;
+        this.diaryDate = diaryDate;
         this.imageUrl = imageUrl;
     }
 

--- a/src/main/java/com/buddy/buddyapi/global/config/AppConfig.java
+++ b/src/main/java/com/buddy/buddyapi/global/config/AppConfig.java
@@ -1,5 +1,6 @@
 package com.buddy.buddyapi.global.config;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
@@ -8,6 +9,13 @@ import org.springframework.web.client.RestTemplate;
 
 @Configuration
 public class AppConfig {
+
+    public static String DIARY_IMAGE_URL;
+
+    @Value("${app.image.base-url}")
+    public void setDiaryImageUrl(String value) {
+        DIARY_IMAGE_URL = value;
+    }
 
     @Bean
     public RestTemplate restTemplate() {

--- a/src/main/java/com/buddy/buddyapi/global/config/JwtAuthenticationFilter.java
+++ b/src/main/java/com/buddy/buddyapi/global/config/JwtAuthenticationFilter.java
@@ -34,11 +34,12 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             @NonNull HttpServletRequest request,
             @NonNull HttpServletResponse response,
             @NonNull FilterChain filterChain)
-            throws ServletException, IOException {
+            throws IOException, ServletException {
+
+        String path = request.getRequestURI();
 
         // 1. OPTIONS 메서드는 토큰 검사 없이 통과 (CORS 예비 요청 처리)
-        if (request.getMethod().equals("OPTIONS")) {
-            response.setStatus(HttpServletResponse.SC_OK);
+        if (request.getMethod().equals("OPTIONS") || path.startsWith("/api/v1/auth/refresh")) {
             filterChain.doFilter(request, response);
             return;
         }

--- a/src/main/java/com/buddy/buddyapi/global/config/SecurityConfig.java
+++ b/src/main/java/com/buddy/buddyapi/global/config/SecurityConfig.java
@@ -27,6 +27,7 @@ public class SecurityConfig {
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)) // 세션 미사용
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/api/v1/auth/**").permitAll() // 명세서의 auth 경로는 모두 허용
+                        .requestMatchers("/images/**").permitAll()
                         .requestMatchers(
                                 "/v3/api-docs/**",
                                 "/swagger-ui/**",

--- a/src/main/java/com/buddy/buddyapi/global/config/WebConfig.java
+++ b/src/main/java/com/buddy/buddyapi/global/config/WebConfig.java
@@ -1,0 +1,42 @@
+package com.buddy.buddyapi.global.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.HttpMessageConverter;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
+
+@Configuration
+@RequiredArgsConstructor
+public class WebConfig implements WebMvcConfigurer {
+    private final ObjectMapper objectMapper;
+
+    @Value("${file.upload-dir}")
+    private String uploadDir;
+
+    // 1. 이미지 조회용 - 서버의 실제 폴더를 /images/** 주소로 연결
+    @Override
+    public void addResourceHandlers(ResourceHandlerRegistry registry) {
+        registry.addResourceHandler("/images/**")
+                .addResourceLocations("file:" + uploadDir);
+    }
+
+    // 2. 이름표 없는 데이터도 Json으로 인식하게 설정(swagger/프론트엔드용)
+    @Override
+    public void extendMessageConverters(List<HttpMessageConverter<?>> converters) {
+        MappingJackson2HttpMessageConverter converter = new MappingJackson2HttpMessageConverter(objectMapper);
+        converter.setSupportedMediaTypes(List.of(
+                MediaType.APPLICATION_JSON,
+                MediaType.valueOf("application/octet-stream")
+        ));
+
+        converters.add( converter);
+
+    }
+}

--- a/src/main/java/com/buddy/buddyapi/repository/DiaryRepository.java
+++ b/src/main/java/com/buddy/buddyapi/repository/DiaryRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
@@ -21,13 +22,12 @@ public interface DiaryRepository extends JpaRepository<Diary, Long> {
             "LEFT JOIN FETCH d.diaryTags dt " +
             "LEFT JOIN FETCH dt.tag " +
             "WHERE d.member = :member " +
-            "AND d.createdAt BETWEEN :start AND :end " +
+            "AND d.diaryDate = :date " +
             "ORDER BY d.createdAt DESC"
     )
-    List<Diary> findAllByMemberAndCreatedAtBetweenOrderByCreatedAtDesc(
+    List<Diary> findAllByMemberAndDiaryDate(
             @Param("member") Member member,
-            @Param("start") LocalDateTime start,
-            @Param("end")LocalDateTime end
+            @Param("date") LocalDate date
     );
 
     // findById로 가능 아예 Member와 함께 조회하면 권한 체크로 더 낫나??

--- a/src/main/java/com/buddy/buddyapi/service/ImageService.java
+++ b/src/main/java/com/buddy/buddyapi/service/ImageService.java
@@ -1,0 +1,67 @@
+package com.buddy.buddyapi.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.UUID;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ImageService {
+
+    @Value("${file.upload-dir}")
+    private String uploadDir;
+
+    public String uploadLocal(MultipartFile file) {
+        if(file.isEmpty()) return null;
+
+        try {
+            // 1. 폴더가 없으면 생성
+            File directory = new File(uploadDir);
+            if (!directory.exists()) directory.mkdirs();
+
+            // 2. 파일 이름 중복 방지 (UUID 사용)
+            String originalName = file.getOriginalFilename();
+            String extension = originalName.substring(originalName.lastIndexOf("."));
+            String savedName = UUID.randomUUID().toString() + extension;
+
+            // 3. 실제 파일 저장
+            File destination = new File(directory.getAbsolutePath() + File.separator + savedName);
+            file.transferTo(destination);
+
+            return savedName;
+
+        } catch (IOException e) {
+            throw new RuntimeException("이미지 저장 실패",e);
+        }
+    }
+
+    public void deleteImage(String fileName) {
+        if (fileName == null || fileName.isEmpty()) {
+            return;
+        }
+
+        try {
+            Path filePath = Paths.get(uploadDir).resolve(fileName).normalize();
+            File file = filePath.toFile();
+
+            if (file.exists()) {
+                file.delete();
+                log.info("파일 삭제 성공: {}", fileName);
+            } else {
+                log.warn("파일 삭제 실패 (파일은 존재하나 삭제되지 않음): {}", fileName);
+            }
+        } catch (Exception e) {
+            log.error("파일 삭제 중 예외 발생: {}, 사유: {}", fileName, e.getMessage(), e);
+        }
+    }
+
+}


### PR DESCRIPTION
- Diary 엔티티 내 사용자 지정 날짜 필드(diaryDate) 추가 및 연동
- 이미지 업로드 시 실제 저장 경로와 외부 노출 URL 주소 설정 분리
- Swagger UI 연동 에러 수정을 위한 WebConfig 컨버터 설정 조정