### PR TITLE
fix: Swagger Mixed Content 에러 해결

### DIFF
--- a/src/main/java/com/buddy/buddyapi/global/config/SwaggerConfig.java
+++ b/src/main/java/com/buddy/buddyapi/global/config/SwaggerConfig.java
@@ -5,8 +5,11 @@ import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.servers.Server;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+
+import java.util.List;
 
 @Configuration
 public class SwaggerConfig {
@@ -25,12 +28,18 @@ public class SwaggerConfig {
                         .scheme("bearer")
                         .bearerFormat("JWT"));
 
+        // 3. 서버 주소 강제 설정
+        Server server = new Server();
+        server.setUrl("https://buddy-api.kro.kr");
+        server.setDescription("운영 서버 (HTTPS)");
+
         return new OpenAPI()
                 .info(new Info()
                         .title("Buddy API 명세서")
                         .description("Buddy 프로젝트의 인증 및 사용자 관련 API")
                         .version("v1.0"))
                 .addSecurityItem(securityRequirement)
-                .components(components);
+                .components(components)
+                .servers(List.of(server));
     }
 }


### PR DESCRIPTION
- HTTPS 환경에서 API 호출 시 프로토콜 불일치로 인한 TypeError 해결
- 운영 서버 주소를 https://buddy-api.kro.kr로 명시적 등록