### PR TITLE
fix: 채팅 세션 삭제 조건 버그 수정 및 일기 삭제 시 세션 정리 로직 개선

### DIFF
--- a/src/main/java/com/buddy/buddyapi/domain/chat/ChatService.java
+++ b/src/main/java/com/buddy/buddyapi/domain/chat/ChatService.java
@@ -105,6 +105,18 @@ public class ChatService {
     }
 
     /**
+     * 채팅 세션을 즉시 삭제합니다.
+     * 일기 삭제 시 연결된 세션을 함께 제거할 때 사용합니다.
+     * chat_message는 ON DELETE CASCADE로 자동 삭제됩니다.
+     *
+     * @param session 삭제할 채팅 세션 엔티티
+     */
+    @Transactional
+    public void deleteSession(ChatSession session) {
+        chatSessionRepository.delete(session);
+    }
+
+    /**
      * AI 서비스를 호출하여 캐릭터의 성격이 반영된 답변을 생성합니다.
      * @param session     현재 대화 세션 (캐릭터 정보 포함)
      * @param userContent 사용자가 입력한 메시지 내용

--- a/src/main/java/com/buddy/buddyapi/domain/chat/ChatSessionRepository.java
+++ b/src/main/java/com/buddy/buddyapi/domain/chat/ChatSessionRepository.java
@@ -23,36 +23,26 @@ public interface ChatSessionRepository extends JpaRepository<ChatSession, Long> 
 
     // 알림 발송용 : 10시간 지남, 알림 안보냄, 일기로 안 만들어진 채팅방
     @Query("""
-        SELECT new com.buddy.buddyapi.domain.chat.dto.PushTargetDto(c.sessionId, m.pushToken) 
-        FROM ChatSession c 
-        JOIN c.member m 
-        WHERE c.createdAt <= :tenHoursAgo 
-          AND c.deletionNotifiedAt IS NULL 
-          AND c.ended = false
-        """)
+        SELECT new com.buddy.buddyapi.domain.chat.dto.PushTargetDto(c.sessionId, m.pushToken)
+        FROM ChatSession c
+        JOIN c.member m
+        WHERE c.createdAt <= :tenHoursAgo
+          AND c.deletionNotifiedAt IS NULL
+          AND NOT EXISTS (
+              SELECT 1 FROM Diary d WHERE d.chatSession.sessionId = c.sessionId
+          )
+    """)
     List<PushTargetDto> findWarningTargets(@Param("tenHoursAgo") LocalDateTime tenHoursAgo, Pageable pageable);
 
-    // 쓰레기 청소용 : 12시간 지남, 일기로 안 만들어진 채팅방 삭제
-    // 벌크연산(Bulk Delete)으로 최적화(N+1)문제 방지
-    // 쓰레기 청소 1단계: 자식(메시지) 먼저 삭제 (FK 에러 방지용)
+    // 쓰레기 청소
     @Modifying(clearAutomatically = true)
     @Query("""
-        DELETE FROM ChatMessage m 
-        WHERE m.chatSession.sessionId IN (
-            SELECT c.sessionId FROM ChatSession c 
-            WHERE c.createdAt <= :twelveHoursAgo 
-              AND c.ended = false
-        )
-        """)
-    int deleteOrphanMessages(@Param("twelveHoursAgo") LocalDateTime twelveHoursAgo);
-
-    // 쓰레기 청소 2단계: 부모(세션) 삭제
-    @Modifying(clearAutomatically = true)
-    @Query("""
-        DELETE FROM ChatSession c 
-        WHERE c.createdAt <= :twelveHoursAgo 
-          AND c.ended = false
-        """)
+    DELETE FROM ChatSession c
+    WHERE c.createdAt <= :twelveHoursAgo
+      AND NOT EXISTS (
+          SELECT 1 FROM Diary d WHERE d.chatSession.sessionId = c.sessionId
+      )
+    """)
     int deleteOrphanSessions(@Param("twelveHoursAgo") LocalDateTime twelveHoursAgo);
 
     @Modifying(clearAutomatically = true)

--- a/src/main/java/com/buddy/buddyapi/domain/diary/DiaryRepository.java
+++ b/src/main/java/com/buddy/buddyapi/domain/diary/DiaryRepository.java
@@ -25,4 +25,14 @@ public interface DiaryRepository extends JpaRepository<Diary, Long>, DiaryReposi
     @Query("SELECT DISTINCT d.diaryDate FROM Diary d WHERE d.member.memberId = :memberId ORDER BY d.diaryDate DESC")
     List<LocalDate> findDistinctDiaryDatesDescByMemberId(@Param("memberId") Long memberId);
 
+    /**
+     * 특정 일기의 session_id를 NULL로 업데이트합니다.
+     * 일기 삭제 전 FK 제약조건 위반 방지를 위해 호출합니다.
+     *
+     * @param diaryId 대상 일기 PK
+     */
+    @Modifying(clearAutomatically = true)
+    @Query("UPDATE Diary d SET d.chatSession = NULL WHERE d.diaryId = :diaryId")
+    void detachSession(@Param("diaryId") Long diaryId);
+
 }

--- a/src/main/java/com/buddy/buddyapi/domain/diary/DiaryService.java
+++ b/src/main/java/com/buddy/buddyapi/domain/diary/DiaryService.java
@@ -203,8 +203,18 @@ public class DiaryService {
                 .orElseThrow(() -> new BaseException(ResultCode.DIARY_NOT_FOUND));
 
         String imageUrl = diary.getImageUrl();
+        ChatSession linkedSession = diary.getChatSession();
+
+        if (linkedSession != null) {
+            diaryRepository.detachSession(diaryId);
+            diaryRepository.flush();
+        }
 
         diaryRepository.delete(diary);
+
+        if (linkedSession != null) {
+            chatService.deleteSession(linkedSession);
+        }
 
         insightService.syncStreakOnDelete(memberId);
 

--- a/src/main/java/com/buddy/buddyapi/global/scheduler/ChatRetentionScheduler.java
+++ b/src/main/java/com/buddy/buddyapi/global/scheduler/ChatRetentionScheduler.java
@@ -72,11 +72,10 @@ public class ChatRetentionScheduler {
     public void cleanUpOrphanChatSessions(){
         LocalDateTime twelveHoursAgo = LocalDateTime.now().minusHours(12);
 
-        int deletedMessages = chatSessionRepository.deleteOrphanMessages(twelveHoursAgo);
         int deletedSessions = chatSessionRepository.deleteOrphanSessions(twelveHoursAgo);
 
         if(deletedSessions > 0) {
-            log.info("잉여 메시지 청소 완료: 12시간이 경과된 채팅 메시지{}개, 세션 {}개를 영구 삭제했습니다.", deletedMessages, deletedSessions);
+            log.info("잉여 메시지 청소 완료: 12시간이 경과된 세션 {}개를 영구 삭제했습니다.", deletedSessions);
         }
     }
 


### PR DESCRIPTION
- [스케줄러] ended=false 조건을 NOT EXISTS (Diary) 로 교체 → 일기가 생성된 세션이 12시간 후 삭제되던 버그 수정
- [스케줄러] deleteOrphanMessages() 제거: ON DELETE CASCADE로 DB 자동 처리
- [일기 삭제] DiaryRepository.detachSession() 추가: FK 제약조건 위반 방지
- [일기 삭제] ChatService.deleteSession() 추가: DDD 규칙 준수
- [일기 삭제] deleteDiary() FK 해제 → diary 삭제 → 세션 삭제 순서 보장